### PR TITLE
Add validation of Username.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :confirmable
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
+  # Validations
   validates_inclusion_of :gender, :in => %w(M F U), allow_nil: true, allow_blank: true
+  validates :username, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,6 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   # Validations
-  validates_inclusion_of :gender, :in => %w(M F U), allow_nil: true, allow_blank: true
-  validates :username, uniqueness: true
+  validates_inclusion_of :gender, :in => %w(M F U), allow_nil: true, allow_blank: false
+  validates :username, presence: true, uniqueness: true, allow_nil: false
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -32,7 +32,7 @@
         .form-group
           = f.label :date_of_birth
           %br/
-          = f.date_select :date_of_birth, class: "form-control"
+          = f.date_select :date_of_birth, :start_year=>Time.now.year, :end_year=>Time.now.year-100, :include_blank => true, :default => nil, class: "form-control"
 
         .form-group
           = f.label :gender

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Activate Mail Opener
   config.action_mailer.delivery_method = :letter_opener
-  config.action_mailer.default_url_options = { :host => 'localhost' }
+  config.action_mailer.default_url_options = { :host => 'musikore.dev' }  # Use Anvil
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = '"Musikore" <do-not-reply@musikore.com>'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Fix the problem where different email addresses may share one same username – this happened even with correct settings in migration.
